### PR TITLE
Arreglo de las rutas de actualización y eliminación de llamadas

### DIFF
--- a/controllers/llamadas/llamadas.js
+++ b/controllers/llamadas/llamadas.js
@@ -64,7 +64,7 @@ const updateCall = async(req, res) =>{
         description: req.body.description,
         comunicationDate: req.body.comunicationDate
     
-    }, {where:{id}});
+    }, {where:{id: req.body.id}});
 
 
     res.send({data});
@@ -81,7 +81,7 @@ const updateCall = async(req, res) =>{
  */
 const deleteCall= async (req, res) => {
 try{
-    const{id} = req;
+    const{id} = req.params;
     const deleteResponse = await callsModel.destroy({
         where: {
             id


### PR DESCRIPTION
En la parte de eliminación de llamadas falto colocar el "params" en la solicitud de respuesta (req) en el cual fue colocado, y en la parte de actualización de llamadas no se obtenía de forma correcta el id por ello se corrigió. 